### PR TITLE
[react-redux-render-props]:corrects the behavior when selector is not provided

### DIFF
--- a/workspaces/react-redux-render-prop/source/WithStore.js
+++ b/workspaces/react-redux-render-prop/source/WithStore.js
@@ -23,7 +23,7 @@ class WithStoreInner extends React.Component {
       this.unsubscribe = this.props.store.subscribe(() => {
         if (this.unmounted) return
         const state = this.props.store.getState()
-        const props = this.props.selector ? this.props.selector(state) : state
+        const props = this.props.selector(state)
         if (!deepEqual(props, this.state, { strict: true })) {
           this.setState({
             ...props
@@ -42,9 +42,15 @@ class WithStoreInner extends React.Component {
   render () {
     const { store, render, children } = this.props
 
-    return render
-      ? render(this.state, store.dispatch)
-      : children(this.state, store.dispatch)
+    if (render) {
+      return this.state
+        ? render(this.state, store.dispatch)
+        : render(store.dispatch)
+    } else {
+      return this.state
+        ? children(this.state, store.dispatch)
+        : children(store.dispatch)
+    }
   }
 }
 

--- a/workspaces/react-redux-render-prop/source/WithStore.test.js
+++ b/workspaces/react-redux-render-prop/source/WithStore.test.js
@@ -48,7 +48,7 @@ describe('WithStore', () => {
     functionArgs = {}
     renderFunction = jest.fn((obj, dispatch) => {
       if (typeof obj === 'function' && dispatch === undefined) {
-        Object.assign(functionArgs, { dispatch })
+        Object.assign(functionArgs, { dispatch: obj })
       } else {
         Object.assign(functionArgs, obj, { dispatch })
       }


### PR DESCRIPTION
Looks like some unfinished business. I hoped it got fixed when adding deep state computation, but it was not done correctly.